### PR TITLE
fix(rpc): handle nil value in preapply result

### DIFF
--- a/lib/rpc.ex
+++ b/lib/rpc.ex
@@ -239,7 +239,7 @@ defmodule Tezex.Rpc do
 
   defp do_preapply_operation(%Rpc{} = rpc, payload) do
     case post(rpc, "/blocks/head/helpers/preapply/operations", payload) do
-      {:ok, [%{"contents" => preapplied_operations}]} ->
+      {:ok, [%{"contents" => preapplied_operations}]} when is_list(preapplied_operations) ->
         applied? =
           Enum.all?(
             preapplied_operations,
@@ -275,8 +275,8 @@ defmodule Tezex.Rpc do
           {:error, errors}
         end
 
-      {:ok, result} ->
-        {:error, result}
+      {:ok, _result} ->
+        {:error, :preapply_failed}
 
       err ->
         err


### PR DESCRIPTION
Seems that sometimes `POST /blocks/head/helpers/preapply/operations` returns `[%{"contents" => preapplied_operations}]` with `preapplied_operations == nil`, this PR handles this case.