### PR TITLE
fix(rpc): return error from get_next_counter_for_account/2

### DIFF
--- a/lib/forge.ex
+++ b/lib/forge.ex
@@ -352,7 +352,12 @@ defmodule Tezex.Forge do
   @spec forge_contract(binary(), io_encoding()) :: binary()
   @spec forge_contract(binary()) :: binary()
   def forge_contract(value, output_encoding \\ :bytes) do
-    [address, entrypoint] = String.split(value, "%", parts: 2)
+    {address, entrypoint} =
+      case String.split(value, "%", parts: 2) do
+        [addr, ep] -> {addr, ep}
+        [addr] -> {addr, nil}
+      end
+
     address_bytes = forge_address(address)
 
     if entrypoint != nil && entrypoint != "default" do

--- a/lib/rpc.ex
+++ b/lib/rpc.ex
@@ -191,7 +191,7 @@ defmodule Tezex.Rpc do
     with {:ok, block_head} <- get_block_at_offset(rpc, offset),
          branch = binary_part(block_head["hash"], 0, 51),
          protocol = block_head["protocol"],
-         counter = get_next_counter_for_account(rpc, wallet_address),
+         {:ok, counter} <- get_next_counter_for_account(rpc, wallet_address),
          operation = prepare_operation(transactions, wallet_address, counter, branch),
          {:ok, preapplied_operations} <-
            preapply_operation(rpc, operation, encoded_private_key, protocol),
@@ -296,9 +296,13 @@ defmodule Tezex.Rpc do
     end
   end
 
-  @spec get_next_counter_for_account(t(), nonempty_binary()) :: integer()
+  @spec get_next_counter_for_account(t(), nonempty_binary()) ::
+          {:ok, integer()} | {:error, :not_integer} | {:error, Finch.Error.t()}
   def get_next_counter_for_account(%Rpc{} = rpc, address) do
-    get_counter_for_account(rpc, address) + 1
+    case get_counter_for_account(rpc, address) do
+      {:error, _} = err -> err
+      n -> {:ok, n + 1}
+    end
   end
 
   @spec get_block(t()) ::

--- a/test/forge_test.exs
+++ b/test/forge_test.exs
@@ -196,4 +196,14 @@ defmodule Tezex.ForgeTest do
     assert {:error, "Operation content is missing required keys: parameters.entrypoint"} =
              ForgeOperation.operation_group(opg)
   end
+
+  test "forge_contract without entrypoint" do
+    addr = "KT1XnTn74bUtxHfDtBmm2bGZAQfhPbvKWR8o"
+    with_entry = "KT1XnTn74bUtxHfDtBmm2bGZAQfhPbvKWR8o%foo"
+
+    # No entrypoint should be equivalent to %default
+    assert Forge.forge_contract(addr) == Forge.forge_address(addr)
+    # With entrypoint, expects address bytes followed by entrypoint string
+    assert Forge.forge_contract(with_entry) == Forge.forge_address(addr) <> "foo"
+  end
 end


### PR DESCRIPTION
Fix `** (ArithmeticError) bad argument in arithmetic expression` error when `get_next_counter_for_account/2` return a tuple 