### PR TITLE
fix(forge_operation): use kind tag instead of string

### DIFF
--- a/lib/crypto/nacl.ex
+++ b/lib/crypto/nacl.ex
@@ -21,7 +21,8 @@ defmodule Tezex.Crypto.NaCl do
   - `{:error, reason}` - Decryption failed
   """
   @spec crypto_secretbox_open(binary(), binary(), binary()) ::
-          {:ok, binary()} | {:error, :decryption_failed}
+          {:ok, binary()}
+          | {:error, :decryption_failed | :invalid_nonce_length | :invalid_key_length}
   def crypto_secretbox_open(_ciphertext, nonce, _key) when byte_size(nonce) != 24 do
     {:error, :invalid_nonce_length}
   end

--- a/lib/forge.ex
+++ b/lib/forge.ex
@@ -360,7 +360,7 @@ defmodule Tezex.Forge do
 
     address_bytes = forge_address(address)
 
-    if entrypoint != nil && entrypoint != "default" do
+    if entrypoint != nil and entrypoint != "default" do
       address_bytes <> entrypoint
     else
       address_bytes

--- a/lib/forge_operation.ex
+++ b/lib/forge_operation.ex
@@ -245,7 +245,10 @@ defmodule Tezex.ForgeOperation do
   def endorsement(content) do
     with :ok <- validate_required_keys(content, ~w(kind level)) do
       content =
-        [forge_tag(content["kind"]), Forge.forge_int32(String.to_integer(content["level"]))]
+        [
+          forge_tag(@operation_tags[content["kind"]]),
+          Forge.forge_int32(String.to_integer(content["level"]))
+        ]
         |> IO.iodata_to_binary()
 
       {:ok, content}
@@ -278,7 +281,7 @@ defmodule Tezex.ForgeOperation do
          {:ok, endorsement} <- inline_endorsement(content["endorsement"]) do
       content =
         [
-          forge_tag(content["kind"]),
+          forge_tag(@operation_tags[content["kind"]]),
           Forge.forge_array(endorsement),
           Forge.forge_int16(String.to_integer(content["slot"]))
         ]
@@ -292,7 +295,10 @@ defmodule Tezex.ForgeOperation do
   def failing_noop(content) do
     with :ok <- validate_required_keys(content, ~w(kind arbitrary)) do
       content =
-        [forge_tag(content["kind"]), Forge.forge_array(content["arbitrary"])]
+        [
+          forge_tag(@operation_tags[content["kind"]]),
+          Forge.forge_array(content["arbitrary"])
+        ]
         |> IO.iodata_to_binary()
 
       {:ok, content}

--- a/lib/forge_operation.ex
+++ b/lib/forge_operation.ex
@@ -53,8 +53,8 @@ defmodule Tezex.ForgeOperation do
     end
   end
 
-  defp forge_tag(tag) do
-    <<tag::size(8)>>
+  defp forge_tag(kind) do
+    <<Map.fetch!(@operation_tags, kind)::size(8)>>
   end
 
   @spec operation(map()) :: {:ok, nonempty_binary()} | {:error, nonempty_binary()}
@@ -100,7 +100,7 @@ defmodule Tezex.ForgeOperation do
     with :ok <- validate_required_keys(content, ~w(kind pkh secret)) do
       content =
         [
-          forge_tag(@operation_tags[content["kind"]]),
+          forge_tag(content["kind"]),
           binary_slice(Forge.forge_address(content["pkh"]), 2..-1//1),
           Base.decode16!(content["secret"], case: :mixed)
         ]
@@ -119,7 +119,7 @@ defmodule Tezex.ForgeOperation do
            ) do
       content =
         [
-          forge_tag(@operation_tags[content["kind"]]),
+          forge_tag(content["kind"]),
           Forge.forge_address(content["source"], :bytes, true),
           Forge.forge_nat(String.to_integer(content["fee"])),
           Forge.forge_nat(String.to_integer(content["counter"])),
@@ -155,7 +155,7 @@ defmodule Tezex.ForgeOperation do
               )) || :ok do
       content =
         [
-          forge_tag(@operation_tags[content["kind"]]),
+          forge_tag(content["kind"]),
           Forge.forge_address(content["source"], :bytes, true),
           Forge.forge_nat(String.to_integer(content["fee"])),
           Forge.forge_nat(String.to_integer(content["counter"])),
@@ -190,7 +190,7 @@ defmodule Tezex.ForgeOperation do
            ) do
       content =
         [
-          forge_tag(@operation_tags[content["kind"]]),
+          forge_tag(content["kind"]),
           Forge.forge_address(content["source"], :bytes, true),
           Forge.forge_nat(String.to_integer(content["fee"])),
           Forge.forge_nat(String.to_integer(content["counter"])),
@@ -221,7 +221,7 @@ defmodule Tezex.ForgeOperation do
            ) do
       content =
         [
-          forge_tag(@operation_tags[content["kind"]]),
+          forge_tag(content["kind"]),
           Forge.forge_address(content["source"], :bytes, true),
           Forge.forge_nat(String.to_integer(content["fee"])),
           Forge.forge_nat(String.to_integer(content["counter"])),
@@ -246,7 +246,7 @@ defmodule Tezex.ForgeOperation do
     with :ok <- validate_required_keys(content, ~w(kind level)) do
       content =
         [
-          forge_tag(@operation_tags[content["kind"]]),
+          forge_tag(content["kind"]),
           Forge.forge_int32(String.to_integer(content["level"]))
         ]
         |> IO.iodata_to_binary()
@@ -281,7 +281,7 @@ defmodule Tezex.ForgeOperation do
          {:ok, endorsement} <- inline_endorsement(content["endorsement"]) do
       content =
         [
-          forge_tag(@operation_tags[content["kind"]]),
+          forge_tag(content["kind"]),
           Forge.forge_array(endorsement),
           Forge.forge_int16(String.to_integer(content["slot"]))
         ]
@@ -296,7 +296,7 @@ defmodule Tezex.ForgeOperation do
     with :ok <- validate_required_keys(content, ~w(kind arbitrary)) do
       content =
         [
-          forge_tag(@operation_tags[content["kind"]]),
+          forge_tag(content["kind"]),
           Forge.forge_array(content["arbitrary"])
         ]
         |> IO.iodata_to_binary()
@@ -314,7 +314,7 @@ defmodule Tezex.ForgeOperation do
            ) do
       content =
         [
-          forge_tag(@operation_tags[content["kind"]]),
+          forge_tag(content["kind"]),
           Forge.forge_address(content["source"], :bytes, true),
           Forge.forge_nat(String.to_integer(content["fee"])),
           Forge.forge_nat(String.to_integer(content["counter"])),
@@ -337,7 +337,7 @@ defmodule Tezex.ForgeOperation do
            ) do
       content =
         [
-          forge_tag(@operation_tags[content["kind"]]),
+          forge_tag(content["kind"]),
           Forge.forge_address(content["source"], :bytes, true),
           Forge.forge_nat(String.to_integer(content["fee"])),
           Forge.forge_nat(String.to_integer(content["counter"])),
@@ -365,7 +365,7 @@ defmodule Tezex.ForgeOperation do
            ) do
       content =
         [
-          forge_tag(@operation_tags[content["kind"]]),
+          forge_tag(content["kind"]),
           Forge.forge_address(content["source"], :bytes, true),
           Forge.forge_nat(String.to_integer(content["fee"])),
           Forge.forge_nat(String.to_integer(content["counter"])),
@@ -394,7 +394,7 @@ defmodule Tezex.ForgeOperation do
            ) do
       content =
         [
-          forge_tag(@operation_tags[content["kind"]]),
+          forge_tag(content["kind"]),
           Forge.forge_address(content["source"], :bytes, true),
           Forge.forge_nat(String.to_integer(content["fee"])),
           Forge.forge_nat(String.to_integer(content["counter"])),

--- a/test/forge_operation_test.exs
+++ b/test/forge_operation_test.exs
@@ -233,6 +233,41 @@ defmodule Tezex.ForgeOperationTest do
     end
   end
 
+  describe "operations using the @operation_tags lookup" do
+    test "endorsement encodes the kind tag, not the kind string" do
+      assert {:ok, result} =
+               ForgeOperation.endorsement(%{"kind" => "endorsement", "level" => "100"})
+
+      # tag for "endorsement" is 0; level is forge_int32(100) = <<0,0,0,100>>
+      assert result == <<0, 0, 0, 0, 100>>
+    end
+
+    test "failing_noop encodes the kind tag, not the kind string" do
+      assert {:ok, result} =
+               ForgeOperation.failing_noop(%{"kind" => "failing_noop", "arbitrary" => "deadbeef"})
+
+      # tag for "failing_noop" is 17; "arbitrary" is wrapped in a forge_array
+      assert result == <<17, 0, 0, 0, 8, "deadbeef">>
+    end
+
+    test "endorsement_with_slot encodes the kind tag, not the kind string" do
+      assert {:ok, result} =
+               ForgeOperation.endorsement_with_slot(%{
+                 "kind" => "endorsement_with_slot",
+                 "endorsement" => %{
+                   "branch" => "BLWdshvgEYbtUaABnmqkMuyMezpfsu36DEJPDJN63CW3TFuk7bP",
+                   "operations" => %{"kind" => "endorsement", "level" => "100"},
+                   "signature" =>
+                     "edsigtqqVg7CM2ynDXRHUfVEdL4LxKAJ1xrM1poMPXZdwVQ3SQ6YBkqPcAuaGYbeqUTrg374dDNFvJKCVfMA7T1Vrotg91Hsuam"
+                 },
+                 "slot" => "1"
+               })
+
+      # tag for "endorsement_with_slot" is 10
+      assert <<10, _rest::binary>> = result
+    end
+  end
+
   test "validate_required_keys/2" do
     assert ForgeOperation.validate_required_keys(%{"a" => 1, "b" => 2}, ~w(a b)) == :ok
 


### PR DESCRIPTION
endorsement/1, endorsement_with_slot/1, failing_noop/1 called forge_tag(content["kind"]) with the kind string instead of the @operation_tags lookup, which raised ArgumentError.